### PR TITLE
Adds more padding to all table cells

### DIFF
--- a/eleven/css/base/table.css
+++ b/eleven/css/base/table.css
@@ -27,7 +27,7 @@ caption {
 td {
   border-bottom: 1px solid var(--bluesky-light-20);
   border-left: 1px solid var(--bluesky-light-20);
-  padding-left: 0.5rem;
+  padding: 0.5rem;
 }
 td:first-child {
   border-left: none
@@ -45,7 +45,7 @@ tr:hover td {
 
 /* header --------------------------------------------------------------------*/
 th {
-  padding-left: 0.5rem;
+  padding: 0.5rem;
   border: 1px solid var(--concrete-light);
   border-right: 0;
   background-color: var(--concrete-light);


### PR DESCRIPTION
Hi

The table listing such as content overview or log messages are a bit close together. Adjusting padding gives them some more room:

<img width="600" alt="padding-left" src="https://cloud.githubusercontent.com/assets/60733/25473666/a26d9674-2b30-11e7-9fc1-f205af146528.png">
<img width="600" alt="padding-full" src="https://cloud.githubusercontent.com/assets/60733/25473665/a26c110a-2b30-11e7-853f-4390f58be5d2.png">

