### PR TITLE
Correct typo: moderen

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
     <article class="w card">
       <div class="card__status card__status--ok"></div>
-      <h4 class="card__title card__title--icon">Moderen UI</h4>
+      <h4 class="card__title card__title--icon">Modern UI</h4>
       <p>All the table listings have been removed for a modern card approach</p>
     </article>
 


### PR DESCRIPTION
Typo on the features section of eleventheme.com

"Moderen UI" => "Modern UI"