### PR TITLE
Differentiating placeholder color & input text color

### DIFF
--- a/eleven/templates/component/form/input/form-input.css
+++ b/eleven/templates/component/form/input/form-input.css
@@ -164,6 +164,9 @@ input[type="search"] + .form-item__icon::before{
 input:placeholder-shown {
   background-color: var(--white);
 }
+input::placeholder {
+    color: var(--bluesky-light-50);
+}
 
 /* default */
 input {


### PR DESCRIPTION
The current placeholder text color - is the same as the text color that users enter.
That confuses users to think there's already a valid input there (while there's no actual input at all)