### PR TITLE
Removed select wrapper classes to fix tabledrag issue.

### DIFF
--- a/eleven/templates/component/form/select/select.html.twig
+++ b/eleven/templates/component/form/select/select.html.twig
@@ -13,7 +13,7 @@
  */
 #}
 {% spaceless %}
-<div class="select {{ attributes.class }}">
+<div class="select">
   <select{{ attributes }}>
     {% for option in options %}
       {% if option.type == 'optgroup' %}


### PR DESCRIPTION
The order on fields that allow multiple values is not being saved. This issues is because the method Drupal.tableDrag.prototype.row.prototype.findSiblings is conflicting with the select wrapper, is returning the wrapper instead of the select itself.